### PR TITLE
release and publish in the same workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,12 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/mdb-fields-cleaner
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+
 
     if: github.event.pull_request.merged
     
@@ -55,3 +61,10 @@ jobs:
           commit: ${{ steps.update-pyproject.outputs.COMMIT }}
           generateReleaseNotes: true
           makeLatest: true
+
+      - name: Build pip
+        run: |
+          poetry install    
+          poetry build
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Release and publish in the same workflow because the publish workflow is not triggered by any event generated by automation.

https://github.com/orgs/community/discussions/25281